### PR TITLE
feat: Implementar endpoint /api/gasto para agregar gastos individuales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
-        "@types/jest": "^29.5.11",
-        "@types/node": "^16.18.72",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^16.18.126",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@types/react-test-renderer": "^18.0.0",
@@ -45,7 +45,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.3.5",
-        "ts-jest": "^29.3.4",
+        "ts-jest": "^29.4.0",
         "typescript": "^4.9.5"
       }
     },
@@ -10775,15 +10775,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-jest": {
-      "version": "29.3.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
-      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
       "dev": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -10799,10 +10798,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -10819,6 +10819,9 @@
           "optional": true
         },
         "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
-    "@types/jest": "^29.5.11",
-    "@types/node": "^16.18.72",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^16.18.126",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@types/react-test-renderer": "^18.0.0",
@@ -47,7 +47,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.5",
-    "ts-jest": "^29.3.4",
+    "ts-jest": "^29.4.0",
     "typescript": "^4.9.5"
   }
 }

--- a/src/pages/api/gasto.ts
+++ b/src/pages/api/gasto.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { appendGasto } from '@/utils/googleSheets';
+
+// Tipos para el request
+interface ExtendedNextApiRequest extends NextApiRequest {
+  body: {
+    fecha: string;
+    monto: number;
+    categoria: string;
+    detalle: string;
+  };
+}
+
+export const config = {
+  api: {
+    bodyParser: true
+  }
+};
+
+export default async function handler(
+  req: ExtendedNextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).json({ success: false, error: 'Método no permitido' });
+    }
+
+    const { fecha, monto, categoria, detalle } = req.body;
+    if (!fecha || !monto || !categoria || !detalle) {
+      return res.status(400).json({ success: false, error: 'Faltan datos requeridos' });
+    }
+
+    // Generar un hash único basado en los datos del gasto
+    const hash = `${fecha}-${monto}-${categoria}-${detalle}`;
+
+    // Agregar gasto a Google Sheets
+    await appendGasto({
+      fecha,
+      monto,
+      categoria,
+      detalle,
+      hash
+    });
+
+    res.status(200).json({
+      success: true
+    });
+
+  } catch (error) {
+    console.error('Error en /api/gasto:', error);
+    res.status(500).json({ success: false, error: error.message });
+  }
+}

--- a/tests/api/gasto.test.ts
+++ b/tests/api/gasto.test.ts
@@ -1,0 +1,77 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Crear un mock que implementa solo los métodos necesarios
+const createMockRequest = (data: any) => {
+  const mock = {
+    body: data,
+    method: 'POST',
+    url: 'http://localhost/api/gasto'
+  };
+  
+  return mock as any;
+};
+
+// Crear y aplicar el mock antes de importar handler
+const mockGoogleSheets = {
+  appendGasto: jest.fn().mockResolvedValue(undefined)
+};
+jest.mock('@/utils/googleSheets', () => mockGoogleSheets);
+
+// Ahora importamos handler después de que el mock esté aplicado
+import handler from '@/pages/api/gasto';
+
+describe('POST /api/gasto', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should process gasto and return success response', async () => {
+    // Mocks
+    const mockGasto = {
+      fecha: '2025-06-05',
+      monto: 100,
+      categoria: 'Test',
+      detalle: 'Test expense'
+    };
+    
+    // Request
+    const mockReq = createMockRequest(mockGasto);
+
+    // Response
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    // Call the handler
+    await handler(mockReq, mockRes as NextApiResponse);
+
+    // Assertions
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true
+    });
+    expect(mockGoogleSheets.appendGasto).toHaveBeenCalledWith({
+      fecha: '2025-06-05',
+      monto: 100,
+      categoria: 'Test',
+      detalle: 'Test expense',
+      hash: '2025-06-05-100-Test-Test expense'
+    });
+  });
+
+  it('should return 400 if required data is missing', async () => {
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    await handler(createMockRequest({}), mockRes as NextApiResponse);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Faltan datos requeridos'
+    });
+  });
+});


### PR DESCRIPTION
- Endpoint POST /api/gasto que recibe un gasto individual
- Genera un hash único basado en los datos del gasto
- Agrega el gasto a Google Sheets usando appendGasto
- Retorna {success: true} en caso de éxito
- Tests unitarios que mockean correctamente appendGasto